### PR TITLE
[ORCA-4811] Add support for `dynamic_route_to` action to `pagerduty_event_orchestration_router`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,3 +76,5 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
+
+replace github.com/heimweh/go-pagerduty => github.com/alexzakabluk/go-pagerduty v0.0.0-20240607142119-ac9a64bba6da

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c h1:kMFnB0vCcX
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/alexzakabluk/go-pagerduty v0.0.0-20240607142119-ac9a64bba6da h1:O2mVKSglj/gEz+Z7GX+L4Y1zGRIiDxPHdfp6Ri7klww=
+github.com/alexzakabluk/go-pagerduty v0.0.0-20240607142119-ac9a64bba6da/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
@@ -95,8 +97,6 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
-github.com/heimweh/go-pagerduty v0.0.0-20240503143637-3459408ac715 h1:DbdS2LIPkhsqgRcQzOAux0RpTJSH8VYOrN4rZZgznak=
-github.com/heimweh/go-pagerduty v0.0.0-20240503143637-3459408ac715/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/pagerduty/import_pagerduty_event_orchestration_path_router_test.go
+++ b/pagerduty/import_pagerduty_event_orchestration_path_router_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/heimweh/go-pagerduty/pagerduty"
 )
 
 func TestAccPagerDutyEventOrchestrationPathRouter_import(t *testing.T) {
@@ -15,11 +14,6 @@ func TestAccPagerDutyEventOrchestrationPathRouter_import(t *testing.T) {
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	orchestration := fmt.Sprintf("tf-orchestration-%s", acctest.RandString(5))
-	dynamicRouteToByNameInput := &pagerduty.EventOrchestrationPathDynamicRouteTo{
-		LookupBy: "service_name",
-		Regex:    ".*",
-		Source:   "event.custom_details.pd_service_name",
-	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -27,14 +21,13 @@ func TestAccPagerDutyEventOrchestrationPathRouter_import(t *testing.T) {
 		CheckDestroy: testAccCheckPagerDutyEventOrchestrationRouterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPagerDutyEventOrchestrationRouterDynamicRouteToConfig(team, escalationPolicy, service, orchestration, dynamicRouteToByNameInput),
+				Config: testAccCheckPagerDutyEventOrchestrationRouterConfigWithMultipleRules(team, escalationPolicy, service, orchestration),
 			},
 			{
-				ResourceName:            "pagerduty_event_orchestration_router.router",
-				ImportStateIdFunc:       testAccCheckPagerDutyEventOrchestrationPathRouterID,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"set.0.rule.0.id", "set.0.rule.1.id"},
+				ResourceName:      "pagerduty_event_orchestration_router.router",
+				ImportStateIdFunc: testAccCheckPagerDutyEventOrchestrationPathRouterID,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/pagerduty/resource_pagerduty_event_orchestration_path_router_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_router_test.go
@@ -337,6 +337,9 @@ func testAccCheckPagerDutyEventOrchestrationRouterDynamicRouteToConfig(t, ep, s,
 				}
 				rule {
 					label = "static routing rule"
+					condition {
+						expression = "event.summary matches part '[prod]'"
+					}
 					actions {
 						route_to = pagerduty_service.bar.id
 					}

--- a/pagerduty/resource_pagerduty_event_orchestration_path_router_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_router_test.go
@@ -337,9 +337,6 @@ func testAccCheckPagerDutyEventOrchestrationRouterDynamicRouteToConfig(t, ep, s,
 				}
 				rule {
 					label = "static routing rule"
-					condition {
-						expression = "event.summary matches part '[prod]'"
-					}
 					actions {
 						route_to = pagerduty_service.bar.id
 					}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
@@ -53,6 +53,7 @@ type EventOrchestrationPathRuleCondition struct {
 type EventOrchestrationPathRuleActions struct {
 	DropEvent                  bool                                               `json:"drop_event"`
 	RouteTo                    string                                             `json:"route_to"`
+	DynamicRouteTo             *EventOrchestrationPathDynamicRouteTo              `json:"dynamic_route_to"`
 	Suppress                   bool                                               `json:"suppress"`
 	Suspend                    *int                                               `json:"suspend"`
 	Priority                   string                                             `json:"priority"`
@@ -64,6 +65,12 @@ type EventOrchestrationPathRuleActions struct {
 	EventAction                string                                             `json:"event_action"`
 	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables"`
 	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions"`
+}
+
+type EventOrchestrationPathDynamicRouteTo struct {
+	Source   string `json:"source,omitempty"`
+	Regex    string `json:"regex,omitempty"`
+	LookupBy string `json:"lookup_by,omitempty"`
 }
 
 type EventOrchestrationPathIncidentCustomFieldUpdate struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -257,7 +257,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.1.1
 ## explicit; go 1.15
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20240503143637-3459408ac715
+# github.com/heimweh/go-pagerduty v0.0.0-20240503143637-3459408ac715 => github.com/alexzakabluk/go-pagerduty v0.0.0-20240607142119-ac9a64bba6da
 ## explicit; go 1.17
 github.com/heimweh/go-pagerduty/pagerduty
 github.com/heimweh/go-pagerduty/persistentconfig
@@ -558,3 +558,4 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/ini.v1 v1.67.0
 ## explicit
 gopkg.in/ini.v1
+# github.com/heimweh/go-pagerduty => github.com/alexzakabluk/go-pagerduty v0.0.0-20240607142119-ac9a64bba6da


### PR DESCRIPTION
## Context

This PR adds support for the `dynamic_route_to` rule action for the `pagerduty_event_orchestration_router` resource. Config validation is out of scope for this ticket and will be added as part of https://pagerduty.atlassian.net/browse/ORCA-4813.

The action can be configured as follows:
```terraform
resource "pagerduty_event_orchestration_router" "my_router" {
	event_orchestration = pagerduty_event_orchestration.my_orch.id

	catch_all {
		actions {
			route_to = "unrouted"
		}
	}
	set {
		id = "start"
		rule {
			disabled = false
			label = "dynamic routing rule"
			actions {
				dynamic_route_to {
					lookup_by = "service_name" # or "service_id"
					regex = ".*"
					source = "event.custom_details.pd_service"
				}
			}
		}
		rule {
			label = "static routing rule"
			actions {
				route_to = pagerduty_service.my_service.id
			}
		}
	}
}
```

## Testing

### Acceptance Tests Passing
![image](https://github.com/alenapan/terraform-provider-pagerduty/assets/47909261/ec97df61-38ae-4854-ba49-ae2ec0f2a158)

:warning: **Note 1:** I couldn't point my environment to a local copy of the current TF Provider branch using dev_overrides so I couldn't test these changes locally. But to verify that acceptance tests indeed do what we expect them to do, I did the following:
1. Temporarily commented out all but the first five steps so we don't have a lot of JSON file versions to comb through in S3: <img width="1347" alt="image" src="https://github.com/alenapan/terraform-provider-pagerduty/assets/47909261/76ac3d5e-71f4-4e87-8900-97122fe17acf">
2. Re-ran the test: <img width="793" alt="image" src="https://github.com/alenapan/terraform-provider-pagerduty/assets/47909261/28882acd-8e38-4de3-91a7-c61dc3aa7eec">
3. Grabbed the orchestration ID from the logs and looked it up in S3: https://us-west-2.console.aws.amazon.com/s3/object/pd-event-rule-engine?region=us-west-2&bucketType=general&prefix=orchestrations%2Frouter%2Faccounts%2F342110%2F03b6bd4d-d2ab-4620-be10-4bc30a020027.json&tab=versions <img width="748" alt="image" src="https://github.com/alenapan/terraform-provider-pagerduty/assets/47909261/56e9216e-51dc-4aa8-9d9f-b60d90a62d72">
4. Went through the file versions and confirmed that they match the expected order of changes: <img width="1103" alt="image" src="https://github.com/alenapan/terraform-provider-pagerduty/assets/47909261/ffad48d5-c333-4d3a-9733-ddbac9921ad8">
  - 1: the Router is created when a parent Orchestration is created
  - 2: Test Step 1 - the Router is updated but it has the same config - no rules
  - 3: Test Step 2 - the Router is updated with one static routing rule
  - 4: Test Step 3 - a dynamic routing rule by service name is added
  - 5: Test Step 4 - the dynamic routing rule is updated to look up by service ID
  - 6: Test Step 5 - the dynamic routing rule is deleted and the static routing rule is updated to have a condition
  - 7: the cleanup step where the router gets reset to an empty state

⚠️ **Note 2:** I noticed that the `TestAccPagerDutyEventOrchestrationPathRouter_import` test is failing, but import tests for unrouted and service orchestrations are also failing on the master branch because of the same error where the `ImportStateVerify` function finds differences in rule IDs in case with Router/Unrouted EOs, and the `enable_event_orchestration_for_service` for Service EO. I added some temporary logs in various spots in the code to confirm that rule IDs are mapped to the resource data when a GET call is made, so I suspect it could be an update to the testing library or something similar that caused the checks to get stricter or run at a different time. I will look into it a bit more but I want to do it outside of the scope of this PR.

✅ **Note 2 Update:** I tested Router import with the latest version of PD TF Provider (3.13.1) locally and confirmed that it's working as expected. So I added the `ImportStateVerifyIgnore: []string{"set.0.rule.0.id", "set.0.rule.1.id"}`  property to the router import test so it doesn't compare rule IDs. All Router tests are passing now but I also [asked](https://pagerduty.slack.com/archives/CMUHTKHS5/p1718311600645989) in the #terraform-provider channel to make sure we are not hiding any import issues: <img width="895" alt="image" src="https://github.com/alenapan/terraform-provider-pagerduty/assets/47909261/90e9da66-c4a9-4a05-b4af-ca39e4d07ec1">

**Local testing steps for posterity:**
1. I referenced an [EO](https://pdt-alenatestaccount.pagerduty.com/event-orchestration/e0a9048f-2a9d-4375-8d79-2d153fe3b730) from my `pdt-` account as a data source in my local `main.tf`:
```terraform
data "pagerduty_event_orchestration" "tf_orch_test" {
 name = "TF Router Import Test EO"
}
```
2. Added a terraform config for a Router:
```terraform
resource "pagerduty_event_orchestration_router" "tf_import_test_router" {
  event_orchestration = data.pagerduty_event_orchestration.tf_orch_test.id

  catch_all {
    actions {
      route_to = "unrouted"
    }
  }
  set {
    id = "start"
    rule {
      actions {
        route_to = "PZ73WUB"
      }
    }
  }
}
```
3. Ran an import command:
```shell
terraform import pagerduty_event_orchestration_router.tf_import_test_router e0a9048f-2a9d-4375-8d79-2d153fe3b730
```
4. Verified in the state file that the rule Id matches the rule Id returned by the API:
  - .tfstate: <img width="740" alt="image" src="https://github.com/alenapan/terraform-provider-pagerduty/assets/47909261/d008f3d6-9191-4d82-80da-877c30d3d293">
  - API response: <img width="818" alt="image" src="https://github.com/alenapan/terraform-provider-pagerduty/assets/47909261/76f7db8f-7364-4470-86ef-07e04573e048">
5. Updated the service ID of the rule and ran `terraform plan` and `terraform apply`:
```terraform
resource "pagerduty_event_orchestration_router" "tf_import_test_router" {
  event_orchestration = data.pagerduty_event_orchestration.tf_orch_test.id

  catch_all {
    actions {
      route_to = "unrouted"
    }
  }
  set {
    id = "start"
    rule {
      actions {
        route_to = "PM0AV05"
      }
    }
  }
}
```
6. Verified that the rule still has the same ID in the state file and in the API response:
  - .tfstate: <img width="943" alt="image" src="https://github.com/alenapan/terraform-provider-pagerduty/assets/47909261/dcc189f2-423f-43de-8d4b-6d49500f5632">
  - API response: <img width="815" alt="image" src="https://github.com/alenapan/terraform-provider-pagerduty/assets/47909261/0ae67c15-dc70-416c-b5e3-d2a61ec3cc16">



