### PR TITLE
[ORCA-4813] Validate Dynamic Routing rules in `pagerduty_event_orchestration_router`

### DIFF
--- a/pagerduty/event_orchestration_path_util.go
+++ b/pagerduty/event_orchestration_path_util.go
@@ -427,3 +427,7 @@ func emptyOrchestrationPathStructBuilder(pathType string) *pagerduty.EventOrches
 
 	return commonEmptyOrchestrationPath()
 }
+
+func isNonEmptyList(arg interface{}) bool {
+	return !isNilFunc(arg) && len(arg.([]interface{})) > 0
+}


### PR DESCRIPTION
### Context
This PR adds the following validation rules for the `pagerduty_event_orchestration_router` resource:

- A Router can have at most one Dynamic Routing rule
- Dynamic Routing rule must be the first rule of the first ("start") set
- A Dynamic Routing rule, if placed correctly as the first rule of the first set, cannot have conditions and the `route_to` action

If any of these rules are violated, an error will be returned during the `terraform plan` stage. 

### Testing

**Note:** I still can't test a local version of the provider so I made the acceptance tests cover extra use cases

- [x] Acceptance tests for the `pagerduty_event_orchestration_router` resource are passing: ![image](https://github.com/alenapan/terraform-provider-pagerduty/assets/47909261/2b549581-ce44-427e-b343-665ab93fb4d7)
- [x] Changes are reflected in [S3](https://us-west-2.console.aws.amazon.com/s3/object/pd-event-rule-engine?region=us-west-2&bucketType=general&prefix=orchestrations%2Frouter%2Faccounts%2F342110%2F62a04524-c103-4eba-83ac-d0d0b039e1b2.json&tab=versions): ![image](https://github.com/alenapan/terraform-provider-pagerduty/assets/47909261/ea50faf8-8258-4dee-8153-b0ae6dfd5630)
- [x] Validation errors are displayed (reflected in the local `terraform.log` file when acceptance tests are run):
  - a Router has more than one Dynamic Routing rule / Dynamic Routing rule is not the first rule: ![image](https://github.com/alenapan/terraform-provider-pagerduty/assets/47909261/17e25db4-4f7d-40b7-bd5c-45b7bf2e9c68)
  - Dynamic Routing rule has invalid configuration (has conditions and/or `route_to` action): ![image](https://github.com/alenapan/terraform-provider-pagerduty/assets/47909261/0d441998-9de4-45c5-ad46-dab031345acd)

