### PR TITLE
add acc test `EventOrchestrationPathRouterDynamicRouteTo_import`

### DIFF
--- a/pagerduty/import_pagerduty_event_orchestration_path_router_test.go
+++ b/pagerduty/import_pagerduty_event_orchestration_path_router_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/heimweh/go-pagerduty/pagerduty"
 )
 
 func TestAccPagerDutyEventOrchestrationPathRouter_import(t *testing.T) {
@@ -22,6 +23,39 @@ func TestAccPagerDutyEventOrchestrationPathRouter_import(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckPagerDutyEventOrchestrationRouterConfigWithMultipleRules(team, escalationPolicy, service, orchestration),
+			},
+			{
+				ResourceName:      "pagerduty_event_orchestration_router.router",
+				ImportStateIdFunc: testAccCheckPagerDutyEventOrchestrationPathRouterID,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"set.0.rule.0.id",
+					"set.0.rule.1.id",
+				},
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyEventOrchestrationPathRouterDynamicRouteTo_import(t *testing.T) {
+	team := fmt.Sprintf("tf-name-%s", acctest.RandString(5))
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	orchestration := fmt.Sprintf("tf-orchestration-%s", acctest.RandString(5))
+	dynamicRouteToByNameInput := &pagerduty.EventOrchestrationPathDynamicRouteTo{
+		LookupBy: "service_name",
+		Regex:    ".*",
+		Source:   "event.custom_details.pd_service_name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyEventOrchestrationRouterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationRouterDynamicRouteToConfig(team, escalationPolicy, service, orchestration, dynamicRouteToByNameInput),
 			},
 			{
 				ResourceName:      "pagerduty_event_orchestration_router.router",


### PR DESCRIPTION
Since import of  `pagerduty_event_orchestration_router` is not being tested for the enhancement in its API as Service and Global Orchestrations do.

## Result of new acceptance test added...

```sh
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyEventOrchestrationPathRouterDynamicRouteTo_import -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
=== RUN   TestAccPagerDutyEventOrchestrationPathRouterDynamicRouteTo_import
--- PASS: TestAccPagerDutyEventOrchestrationPathRouterDynamicRouteTo_import (17.53s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     19.814s
```