### PR TITLE
[ORCA-5140] Add support for Event Orchestration External Data Cache Variables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,3 +76,5 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
+
+replace github.com/heimweh/go-pagerduty => github.com/alenapan/go-pagerduty v0.0.0-20250214201653-b8d11443fbc3

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c h1:kMFnB0vCcX
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/alenapan/go-pagerduty v0.0.0-20250214201653-b8d11443fbc3 h1:MBfCyrZBjR+vny6GBIdZlIelQZA11YL7EQK1GjdSiwQ=
+github.com/alenapan/go-pagerduty v0.0.0-20250214201653-b8d11443fbc3/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
@@ -95,8 +97,6 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
-github.com/heimweh/go-pagerduty v0.0.0-20250214190935-c474ec404dae h1:le7p/QnSPOQ4tnt+xjrAIu58JOdPyiNauGR8B2hRaoU=
-github.com/heimweh/go-pagerduty v0.0.0-20250214190935-c474ec404dae/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/pagerduty/resource_pagerduty_event_orchestration_global_cache_variable.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_global_cache_variable.go
@@ -16,7 +16,7 @@ func resourcePagerDutyEventOrchestrationGlobalCacheVariable() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourcePagerDutyEventOrchestrationGlobalCacheVariableImport,
 		},
-		CustomizeDiff: checkConfiguration,
+		CustomizeDiff: checkEventOrchestrationCacheVariableConfiguration,
 		Schema: map[string]*schema.Schema{
 			"event_orchestration": {
 				Type:     schema.TypeString,

--- a/pagerduty/resource_pagerduty_event_orchestration_service_cache_variable.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_service_cache_variable.go
@@ -16,7 +16,7 @@ func resourcePagerDutyEventOrchestrationServiceCacheVariable() *schema.Resource 
 		Importer: &schema.ResourceImporter{
 			StateContext: resourcePagerDutyEventOrchestrationServiceCacheVariableImport,
 		},
-		CustomizeDiff: checkConfiguration,
+		CustomizeDiff: checkEventOrchestrationCacheVariableConfiguration,
 		Schema: map[string]*schema.Schema{
 			"service": {
 				Type:     schema.TypeString,

--- a/pagerduty/resource_pagerduty_event_orchestration_service_cache_variable_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_service_cache_variable_test.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -26,20 +27,46 @@ func TestAccPagerDutyEventOrchestrationServiceCacheVariable_Basic(t *testing.T) 
 	svcn1 := "svc_1"
 	name2 := fmt.Sprintf("tf_service_cache_variable_updated_%s", acctest.RandString(5))
 	svcn2 := "svc_2"
-
+	invalidConfigRecentValue := `
+		configuration {
+			type = "recent_value"
+			regex = ".*"
+			ttl_seconds = 300
+		}
+	`
+	invalidConfigTriggerEventCount := `
+		configuration {
+			type = "trigger_event_count"
+			data_type = "string"
+			ttl_seconds = 60
+		}
+	`
+	invalidConfigExternalData := `
+		configuration {
+			type = "external_data"
+			data_type = "boolean"
+		}
+	`
 	config1 := `
 		configuration {
-  		type = "trigger_event_count"
-  		ttl_seconds = 60
-    }
-  `
+			type = "trigger_event_count"
+			ttl_seconds = 60
+		}
+	`
 	config2 := `
 		configuration {
-  		type = "recent_value"
-  		source = "event.summary"
-  		regex = ".*"
-    }
-  `
+			type = "recent_value"
+			source = "event.summary"
+			regex = ".*"
+		}
+	`
+	config3 := `
+		configuration {
+			type = "external_data"
+			data_type = "boolean"
+			ttl_seconds = 1200
+		}
+	`
 	cond1 := ``
 	cond2 := `
 		condition {
@@ -54,6 +81,25 @@ func TestAccPagerDutyEventOrchestrationServiceCacheVariable_Basic(t *testing.T) 
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyEventOrchestrationServiceCacheVariableDestroy,
 		Steps: []resource.TestStep{
+			// cache variable with an invalid configuration - recent_value:
+			{
+				Config:      testAccCheckPagerDutyEventOrchestrationServiceCacheVariableConfig(svc, name1, svcn1, disabled1, invalidConfigRecentValue, cond1),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Invalid configuration: regex and source cannot be null, and data_type and ttl_seconds cannot be used when type is recent_value"),
+			},
+			// cache variable with an invalid configuration - trigger_event_count:
+			{
+				Config:      testAccCheckPagerDutyEventOrchestrationServiceCacheVariableConfig(svc, name1, svcn1, disabled1, invalidConfigTriggerEventCount, cond1),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Invalid configuration: regex, source, and data_type cannot be used when type is trigger_event_count"),
+			},
+			// cache variable with an invalid configuration - external_data:
+			{
+				Config:      testAccCheckPagerDutyEventOrchestrationServiceCacheVariableConfig(svc, name1, svcn1, disabled1, invalidConfigExternalData, cond1),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Invalid configuration: data_type and ttl_seconds cannot be null when type is external_data"),
+			},
+			// configure a valid cache variable:
 			{
 				Config: testAccCheckPagerDutyEventOrchestrationServiceCacheVariableConfig(svc, name1, svcn1, disabled1, config1, cond1),
 				Check: resource.ComposeTestCheckFunc(
@@ -78,6 +124,16 @@ func TestAccPagerDutyEventOrchestrationServiceCacheVariable_Basic(t *testing.T) 
 					resource.TestCheckResourceAttr(cv, "configuration.0.type", "recent_value"),
 					resource.TestCheckResourceAttr(cv, "configuration.0.source", "event.summary"),
 					resource.TestCheckResourceAttr(cv, "configuration.0.regex", ".*"),
+				),
+			},
+			// update config again:
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationServiceCacheVariableConfig(svc, name1, svcn1, disabled1, config3, cond1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyEventOrchestrationServiceCacheVariableID(cv, svcn1),
+					resource.TestCheckResourceAttr(cv, "configuration.0.type", "external_data"),
+					resource.TestCheckResourceAttr(cv, "configuration.0.data_type", "boolean"),
+					resource.TestCheckResourceAttr(cv, "configuration.0.ttl_seconds", "1200"),
 				),
 			},
 			// update condition:

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_cache_variable.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_cache_variable.go
@@ -15,10 +15,12 @@ type EventOrchestrationCacheVariableCondition struct {
 // Configuration for a cache variable changes depending on the type:
 //   - if `Type` is `recent_value`; then use `Regex` and `Source`
 //   - if `Type` is `trigger_event_count`; then use `TTLSeconds`
+//   - if `Type` is `external_data`; then use `DataType` and `TTLSeconds`
 type EventOrchestrationCacheVariableConfiguration struct {
 	Type       string `json:"type,omitempty"`
 	Regex      string `json:"regex,omitempty"`
 	Source     string `json:"source,omitempty"`
+	DataType   string `json:"data_type,omitempty"`
 	TTLSeconds int    `json:"ttl_seconds,omitempty"`
 }
 
@@ -28,6 +30,7 @@ type EventOrchestrationCacheVariable struct {
 	Disabled      bool                                          `json:"disabled"`
 	Conditions    []*EventOrchestrationCacheVariableCondition   `json:"conditions"`
 	Configuration *EventOrchestrationCacheVariableConfiguration `json:"configuration,omitempty"`
+	DataEndpoint  string                                        `json:"data_endpoint,omitempty"`
 	CreatedAt     string                                        `json:"created_at,omitempty"`
 	CreatedBy     *UserReference                                `json:"created_by,omitempty"`
 	UpdatedAt     string                                        `json:"updated_at,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -261,7 +261,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.1.1
 ## explicit; go 1.15
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20250214190935-c474ec404dae
+# github.com/heimweh/go-pagerduty v0.0.0-20250214190935-c474ec404dae => github.com/alenapan/go-pagerduty v0.0.0-20250214201653-b8d11443fbc3
 ## explicit; go 1.17
 github.com/heimweh/go-pagerduty/pagerduty
 github.com/heimweh/go-pagerduty/persistentconfig
@@ -561,3 +561,4 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/ini.v1 v1.67.0
 ## explicit
 gopkg.in/ini.v1
+# github.com/heimweh/go-pagerduty => github.com/alenapan/go-pagerduty v0.0.0-20250214201653-b8d11443fbc3

--- a/website/docs/d/event_orchestration_global_cache_variable.html.markdown
+++ b/website/docs/d/event_orchestration_global_cache_variable.html.markdown
@@ -36,13 +36,14 @@ The following arguments are supported:
 ## Attributes Reference
 
 * `disabled` - Indicates whether the Cache Variable is disabled and would therefore not be evaluated.
-* `condition` - Conditions to be evaluated in order to determine whether or not to update the Cache Variable's stored value.
+* `condition` - Conditions to be evaluated in order to determine whether or not to update the Cache Variable's stored value. This attribute can only be used when `configuration.0.type` is `recent_value` or `trigger_event_count`.
   * `expression`- A [PCL condition][2] string.
 * `configuration` - A configuration object to define what and how values will be stored in the Cache Variable.
-  * `type` - The [type of value][1] to store into the Cache Variable. Can be one of: `recent_value` or `trigger_event_count`.
+  * `type` - The [type of value][1] to store into the Cache Variable. Can be one of: `recent_value`, `trigger_event_count` or `external_data`.
   * `source` - The path to the event field where the `regex` will be applied to extract a value. You can use any valid [PCL path][3]. This field is only used when `type` is `recent_value`
   * `regex` - A [RE2 regular expression][4] that will be matched against the field specified via the `source` argument. This field is only used when `type` is `recent_value`
-  * `ttl_seconds` - The number of seconds indicating how long to count incoming trigger events for. This field is only used when `type` is `trigger_event_count`
+  * `ttl_seconds` - The number of seconds indicating how long to count incoming trigger events for. This field is only used when `type` is `trigger_event_count` or `external_data`
+  * `data_type` - The type of data that will eventually be set for the Cache Variable via an API request. This field is only used when type is `external_data`
 
 
 [1]: https://support.pagerduty.com/docs/event-orchestration-variables

--- a/website/docs/d/event_orchestration_service_cache_variable.html.markdown
+++ b/website/docs/d/event_orchestration_service_cache_variable.html.markdown
@@ -63,13 +63,14 @@ The following arguments are supported:
 ## Attributes Reference
 
 * `disabled` - Indicates whether the Cache Variable is disabled and would therefore not be evaluated.
-* `condition` - Conditions to be evaluated in order to determine whether or not to update the Cache Variable's stored value.
+* `condition` - Conditions to be evaluated in order to determine whether or not to update the Cache Variable's stored value. This attribute can only be used when `configuration.0.type` is `recent_value` or `trigger_event_count`.
   * `expression`- A [PCL condition][2] string.
 * `configuration` - A configuration object to define what and how values will be stored in the Cache Variable.
-  * `type` - The [type of value][1] to store into the Cache Variable. Can be one of: `recent_value` or `trigger_event_count`.
+  * `type` - The [type of value][1] to store into the Cache Variable. Can be one of: `recent_value`, `trigger_event_count` or `external_data`.
   * `source` - The path to the event field where the `regex` will be applied to extract a value. You can use any valid [PCL path][3]. This field is only used when `type` is `recent_value`
   * `regex` - A [RE2 regular expression][4] that will be matched against the field specified via the `source` argument. This field is only used when `type` is `recent_value`
-  * `ttl_seconds` - The number of seconds indicating how long to count incoming trigger events for. This field is only used when `type` is `trigger_event_count`
+  * `ttl_seconds` - The number of seconds indicating how long to count incoming trigger events for. This field is only used when `type` is `trigger_event_count` or `external_data`
+  * `data_type` - The type of data that will eventually be set for the Cache Variable via an API request. This field is only used when type is `external_data`
 
 
 [1]: https://support.pagerduty.com/docs/event-orchestration-variables


### PR DESCRIPTION
## Changes

This PR adds support for the `external_data` cache variable type to the following resources and data sources:
- `pagerduty/resource_pagerduty_event_orchestration_global_cache_variable.go`
- `pagerduty/resource_pagerduty_event_orchestration_service_cache_variable.go`
- `pagerduty/data_source_pagerduty_event_orchestration_global_cache_variable.go`
- `pagerduty/data_source_pagerduty_event_orchestration_service_cache_variable.go`

It also extends the documentation for Cache Variable resources and data sources to reflect the new type.

## Testing

### Provider Changes

- [x] Acceptance Tests are passing:
  - Resources: ![image](https://github.com/user-attachments/assets/fd86897e-85fd-4e50-a732-36d37564e507)
  - Data Sources: ![image](https://github.com/user-attachments/assets/10918252-af33-4098-b6bf-2581065f605a)
- [x] Manual QA is performed with a local build of the provider: https://github.com/PagerDuty/terraform-provider-pagerduty-internal/pull/12 

### Documentation Updates
Used the [Doc Preview Tool ](https://registry.terraform.io/tools/doc-preview)to test the documentation updates

- `website/docs/d/event_orchestration_global_cache_variable.html.markdown` ![image](https://github.com/user-attachments/assets/4ea88a1a-2c9d-4138-8b90-87ab3a898c4e)
- `website/docs/d/event_orchestration_service_cache_variable.html.markdown` ![image](https://github.com/user-attachments/assets/4fa35e6b-6146-4bb6-9a85-9b79ed6ecafc)
- `website/docs/r/event_orchestration_global_cache_variable.html.markdown` ![image](https://github.com/user-attachments/assets/1edad06b-347e-4fbc-a199-39f20f5a237d)
- `website/docs/r/event_orchestration_service_cache_variable.html.markdown` ![image](https://github.com/user-attachments/assets/fe865dcf-053a-4781-8d1f-be4a07ff973b)